### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/StackConfigPlugin.ts
+++ b/src/StackConfigPlugin.ts
@@ -68,22 +68,27 @@ export default class StackConfigPlugin implements IStackConfig {
         shortcut: 'p',
         usage:
           'Specify the location of the `stack-outputs.json` file ' + '(e.g. "--path .serverless or -p .serverless)',
+        type: 'string',
       },
       profile: {
         shortcut: 'p',
         usage: 'AWS profile name',
+        type: 'string',
       },
       region: {
         shortcut: 'r',
         usage: 'Region of the service',
+        type: 'string',
       },
       stage: {
         shortcut: 's',
         usage: 'Stage of the service',
+        type: 'string',
       },
       verbose: {
         shortcut: 'v',
         usage: 'Show all stack events during deployment',
+        type: 'boolean',
       },
     };
 


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - StackConfigPlugin for "path", "profile", "region", "stage", "verbose"
```